### PR TITLE
Make parameter repeatable in camera-open prim and default to 0 args

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ vid:camera-names => ["Logitech Camera"]
 ```
 
 ### `vid:camera-open`
+### <tt>(vid:camera-open <i>camera-name</i>)</tt>
 
 Opens the named camera as a video source.
 If no name is provided, opens the first camera that would be listed by `camera-names`.
@@ -60,7 +61,7 @@ If no name is provided, opens the first camera that would be listed by `camera-n
 Example:
 ```NetLogo
 vid:camera-open ; opens first camera
-vid:camera-open "Logitech Camera"
+(vid:camera-open "Logitech Camera")
 ```
 
 Errors:

--- a/src/main/scala/CameraOpen.scala
+++ b/src/main/scala/CameraOpen.scala
@@ -5,7 +5,7 @@ import org.nlogo.api.{ Argument, Command, Context, ExtensionException }
 
 class CameraOpen(vid: VideoSourceContainer, cameras: CameraFactory) extends Command {
   override def getSyntax =
-    Syntax.commandSyntax(right = List(Syntax.StringType), minimumOption = Some(0), defaultOption = Some(1))
+    Syntax.commandSyntax(right = List(Syntax.StringType | Syntax.RepeatableType), defaultOption = Some(0))
 
   def perform(args: Array[Argument], context: Context): Unit = {
     val cameraName =


### PR DESCRIPTION
Despite what the documentation was saying, there was no way to call
`vid-camera-open` without arguments.

I have also changed the default to 0 arguments, both to be consistent with
other primitives and because I expect that, most of the time, opening the
first camera available makes sense.