### PR TITLE
Change default number of arguments of `vid:recorder-start` to 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ If height and width are not supplied, they will be determined from the first fra
 Example:
 
 ```NetLogo
-(vid:start-recorder)
+vid:start-recorder
 (vid:start-recorder 640 480)
 ```
 

--- a/src/main/scala/StartRecorder.scala
+++ b/src/main/scala/StartRecorder.scala
@@ -7,8 +7,7 @@ class StartRecorder(recorder: Recorder) extends Command {
 
   def getSyntax = Syntax.commandSyntax(
     right = List(Syntax.NumberType | Syntax.RepeatableType),
-    defaultOption = Some(2),
-    minimumOption = Some(0))
+    defaultOption = Some(0))
 
   def perform(args: Array[Argument], context: Context): Unit = {
     try {


### PR DESCRIPTION
For consistence with #3, #4.

@mrerrormessage, this may require changes to the autoconverter, which currently puts in `(vid:recorder-start)` instead of the newly possible parentheses-less `vid:recorder-start`.