### PR TITLE
Index out of bounds exception when trying to save an empty movie

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ Errors:
 
 * Message `"vid: recorder not started"`: The recorder has not been started. Start the recorder with `vid:start-recorder`.
 * Message `"vid: no such directory"`: The directory containing the specified save file does not exist.
+* Message `"vid: no frames recorded"`: You tried to save a recording with no frames recorded. Check that you are recording properly or use `vid:reset-recording` to to change the recording format without saving.
 
 ## Terms of Use
 

--- a/src/main/scala/MP4Recorder.scala
+++ b/src/main/scala/MP4Recorder.scala
@@ -35,9 +35,14 @@ class MP4Recorder extends Recorder {
       throw Recorder.NotRecording
     if (! Files.exists(dest.toAbsolutePath.getParent))
       throw new FileNotFoundException("no such directory: " + dest.toAbsolutePath.toString)
-    activeRecording.foreach(_.finish())
-    recordingPath.foreach(src => Files.copy(src, dest, REPLACE_EXISTING))
-    reset()
+    try {
+      activeRecording.foreach(_.finish())
+      recordingPath.foreach(src => Files.copy(src, dest, REPLACE_EXISTING))
+    } catch {
+      case e: IndexOutOfBoundsException => throw Recorder.NoFrames
+    } finally {
+      reset()
+    }
   }
 
   def reset(): Unit = {

--- a/src/main/scala/Recorder.scala
+++ b/src/main/scala/Recorder.scala
@@ -15,4 +15,5 @@ trait Recorder {
 object Recorder {
   object AlreadyStarted extends Exception("Recorder is already recording")
   object NotRecording extends Exception("Recorder is not recording")
+  object NoFrames extends Exception("Recorder has not recorded anything")
 }

--- a/src/main/scala/SaveRecording.scala
+++ b/src/main/scala/SaveRecording.scala
@@ -21,6 +21,7 @@ class SaveRecording(recorder: Recorder) extends Command {
     } catch {
       case _: FileNotFoundException => throw new ExtensionException("vid: no such directory")
       case Recorder.NotRecording    => throw new ExtensionException("vid: recorder not started")
+      case Recorder.NoFrames        => throw new ExtensionException("vid: no frames recorded")
     }
   }
 }

--- a/src/test/scala/MP4RecorderTest.scala
+++ b/src/test/scala/MP4RecorderTest.scala
@@ -88,4 +88,11 @@ class MP4RecorderTest extends FunSuite {
       intercept[Recorder.NotRecording.type] { recorder.save(tempFile) }
     }
   }
+
+  test("saving with no frames raises Recorder.NoFrames") {
+    new Helper {
+      recorder.start()
+      intercept[Recorder.NoFrames.type] { recorder.save(tempFile) }
+    }
+  }
 }

--- a/src/test/scala/RecorderSpec.scala
+++ b/src/test/scala/RecorderSpec.scala
@@ -119,6 +119,14 @@ class RecorderSpec extends FeatureSpec with GivenWhenThen with VidHelpers {
         assert(Files.exists(Paths.get("foo.mp4")))
       }
     }
+
+    scenario("save-recording throws an exception if no frames have been recorded") {
+      new Helpers with ExpectError {
+        givenRecorderStarted
+        whenRunForError("vid:save-recording", vid.`save-recording`("error.mp4"))
+        thenShouldSeeError("vid: no frames recorded")
+      }
+    }
   }
 
   feature("record-view") {

--- a/src/test/scala/VidHelpers.scala
+++ b/src/test/scala/VidHelpers.scala
@@ -169,6 +169,8 @@ class DummyRecorder extends Recorder {
       else dest
     if (! Files.exists(d.toAbsolutePath.getParent))
       throw new java.io.FileNotFoundException("no such directory: " + d.toString)
+    if (lastFrame == null)
+      throw Recorder.NoFrames
     Files.write(d, "test".getBytes)
   }
 }


### PR DESCRIPTION
In a blank model:

```
extensions [ vid ]
to setup
  clear-all
  vid:start-recorder
  vid:save-recording "test.mp4"
end
```
Exception:
```
java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
 at java.util.ArrayList.rangeCheck(ArrayList.java:653)
 at java.util.ArrayList.get(ArrayList.java:429)
 at org.jcodec.codecs.h264.H264Utils.createMOVSampleEntry(H264Utils.java:338)
 at org.jcodec.api.SequenceEncoder.finish(SequenceEncoder.java:92)
 at org.nlogo.extensions.vid.MP4Recorder$$anonfun$save$1.apply(MP4Recorder.scala:38)
 at org.nlogo.extensions.vid.MP4Recorder$$anonfun$save$1.apply(MP4Recorder.scala:38)
 at scala.Option.foreach(Option.scala:257)
 at org.nlogo.extensions.vid.MP4Recorder.save(MP4Recorder.scala:38)
 at org.nlogo.extensions.vid.SaveRecording.perform(SaveRecording.scala:20)
 at org.nlogo.prim._extern.perform(_extern.java:38)
 at org.nlogo.nvm.Context.stepConcurrent(Context.java:91)
 at org.nlogo.nvm.ConcurrentJob.step(ConcurrentJob.java:83)
 at org.nlogo.job.JobThread.org$nlogo$job$JobThread$$runPrimaryJobs(JobThread.scala:133)
 at org.nlogo.job.JobThread$$anonfun$run$1.apply$mcV$sp(JobThread.scala:68)
 at org.nlogo.job.JobThread$$anonfun$run$1.apply(JobThread.scala:66)
 at org.nlogo.job.JobThread$$anonfun$run$1.apply(JobThread.scala:66)
 at scala.util.control.Exception$Catch.apply(Exception.scala:103)
 at org.nlogo.api.Exceptions$.handling(Exceptions.scala:41)
 at org.nlogo.job.JobThread.run(JobThread.scala:65)

NetLogo 6.0-M8
main: org.nlogo.app.AppFrame
thread: JobThread
Java HotSpot(TM) 64-Bit Server VM 1.8.0_91 (Oracle Corporation; 1.8.0_91-b14)
operating system: Linux 4.2.0-41-generic (amd64 processor)
Scala version 2.11.8
JOGL: (3D View not initialized)
OpenGL Graphics: (3D View not initialized)
model: Untitled

05:05:25.481 SwitchedTabsEvent (org.nlogo.app.Tabs) AWT-EventQueue-0
05:05:25.481 RuntimeErrorEvent (org.nlogo.app.App$$anon$1 (org.nlogo.window.GUIWorkspace)) AWT-EventQueue-0
05:05:25.449 TickStateChangeEvent (org.nlogo.app.App$$anon$1 (org.nlogo.window.GUIWorkspace)) JobThread
05:05:25.448 OutputEvent (org.nlogo.app.App$$anon$1 (org.nlogo.window.GUIWorkspace)) AWT-EventQueue-0
05:05:25.447 AddJobEvent (org.nlogo.app.CommandLine) AWT-EventQueue-0
05:05:25.447 OutputEvent (org.nlogo.app.CommandLine) AWT-EventQueue-0
05:05:25.447 CompiledEvent (org.nlogo.window.CompilerManager) AWT-EventQueue-0
05:05:25.437 CompileMoreSourceEvent (org.nlogo.app.CommandLine) AWT-EventQueue-0
05:05:25.424 PeriodicUpdateEvent (org.nlogo.app.App$$anon$1 (org.nlogo.window.GUIWorkspace)) AWT-EventQueue-0
05:05:25.224 PeriodicUpdateEvent (org.nlogo.app.App$$anon$1 (org.nlogo.window.GUIWorkspace)) AWT-EventQueue-0
```