### PR TITLE
`record-view` output distorted for non-square views

### DIFF
--- a/documentation.conf
+++ b/documentation.conf
@@ -270,7 +270,7 @@ Errors:
   {
     name: show-player
     type: command,
-    arguments: [ {name: "height", type: "number"}, {name: "width", type: "number"} ],
+    arguments: [ {name: "width", type: "number"}, {name: "height", type: "number"} ],
     description: """
 Shows a player in a separate window.
 If there is no video source, the window will be an empty black frame.
@@ -392,7 +392,7 @@ vid:recorder-status ; => "inactive"
 Starts the recorder.
 If the recorder is already running this will cause an error to be raised.
 If desired, a recording width and height can be supplied.
-If height and width are not supplied, they will be determined from the first frame recorded.
+If width and height are not supplied, they will be determined from the first frame recorded.
 
 Example:
 

--- a/src/main/scala/MP4Recorder.scala
+++ b/src/main/scala/MP4Recorder.scala
@@ -27,7 +27,14 @@ class MP4Recorder extends Recorder {
 
   def setResolution(width: Int, height: Int): Unit = {
     if (activeResolution.isEmpty)
-      activeResolution = Some((width, height))
+      activeResolution = Some(roundResolution(width, height))
+  }
+
+  private def roundResolution(width: Int, height: Int): (Int, Int) = {
+    if (width % 2 == 1 && height % 2 == 1) (width + 1, height + 1)
+    else if (width % 2 == 1)               (width + 1, height)
+    else if (height % 2 == 1)              (width,     height + 1)
+    else                                   (width,     height)
   }
 
   def save(dest: Path): Unit = {
@@ -53,7 +60,7 @@ class MP4Recorder extends Recorder {
 
   def recordFrame(image: BufferedImage): Unit = {
     if (activeResolution.isEmpty)
-      activeResolution = Some((image.getWidth, image.getHeight))
+      activeResolution = Some(roundResolution(image.getWidth, image.getHeight))
     if (activeRecording.isDefined)
       activeRecording.foreach { recording =>
         activeResolution.foreach { res =>

--- a/src/main/scala/MP4Recorder.scala
+++ b/src/main/scala/MP4Recorder.scala
@@ -58,7 +58,7 @@ class MP4Recorder extends Recorder {
       activeRecording.foreach { recording =>
         activeResolution.foreach { res =>
           val rgbImage = new BufferedImage(res._1, res._2, BufferedImage.TYPE_INT_RGB)
-          rgbImage.getGraphics.drawImage(image, 0, 0, res._1, res._2, 0, 0, image.getHeight, image.getWidth, null)
+          rgbImage.getGraphics.drawImage(image, 0, 0, res._1, res._2, 0, 0, image.getWidth, image.getHeight, null)
           recording.encodeNativeFrame(AWTUtil.fromBufferedImage(rgbImage))
         }
       }

--- a/src/test/scala/MovieTest.scala
+++ b/src/test/scala/MovieTest.scala
@@ -27,7 +27,7 @@ class MovieTest extends FunSuite with AsyncAssertions {
   val NotFoundMoviePath = "/tmp/notreal"
   val InvalidMoviePath  = "src/test/resources/small.ogv"
 
-  val ValidMovieURL = "http://download.wavetlan.com/SVV/Media/HTTP/H264/Other_Media/H264_test8_voiceclip_mp4_480x320.mp4"
+  val ValidMovieURL = "http://www.sample-videos.com/video/mp4/720/big_buck_bunny_720p_1mb.mp4"
   val InvalidMovieURL = "http://v2v.cc/~j/samples/failed_vorbis_size.ogv"
   val RssMovieURL = "rss://raw.githubusercontent.com/NetLogo/vid/master/src/test/resources/small.mp4"
   val NotFoundMovieURL = "http://raw.githubusercontent.com/NetLogo/vid/master/src/test/resources/notreal.mp4"

--- a/src/test/scala/NetLogoDummies.scala
+++ b/src/test/scala/NetLogoDummies.scala
@@ -46,6 +46,7 @@ class FakeWorkspace extends org.nlogo.api.Workspace {
   // Members declared in org.nlogo.api.RandomServices
   def auxRNG: org.nlogo.api.MersenneTwisterFast = ???
   def mainRNG: org.nlogo.api.MersenneTwisterFast = ???
+  def seedRNGs(seed: Int): Unit = ???
 
   // Members declared in org.nlogo.api.ViewSettings
   def drawSpotlight: Boolean = ???
@@ -70,6 +71,7 @@ class FakeWorkspace extends org.nlogo.api.Workspace {
   def clearTicks(): Unit = ???
   def compilerTestingMode: Boolean = ???
   def dispose(): Unit = ???
+  def getCompilationEnvironment: org.nlogo.core.CompilationEnvironment = ???
   def exportAllPlots(path: String): Unit = ???
   def exportDrawing(path: String,format: String): Unit = ???
   def exportInterface(path: String): Unit = {


### PR DESCRIPTION
While `vid:record-view` output (from `vid:save-recording`) is fine for square views (equal height and width), it distorts views where the height and width are not equal. _I think_ the height and width of the output mp4 are being reversed (hence why square views work fine).

I'm pretty sure the issue is here:
https://github.com/NetLogo/vid/blob/hexy/src/main/scala/MP4Recorder.scala#L61 

It seems that `image.getHeight` and `image.getWidth` need to be reversed.

[sample_videos.zip](https://github.com/NetLogo/vid/files/482912/sample_videos.zip)
